### PR TITLE
Convert to f-string literals

### DIFF
--- a/asyncprawcore/auth.py
+++ b/asyncprawcore/auth.py
@@ -172,9 +172,7 @@ class BaseAuthorizer(object):
     def _validate_authenticator(self):
         if not isinstance(self._authenticator, self.AUTHENTICATOR_CLASS):
             raise InvalidInvocation(
-                "Must use a authenticator of type {}.".format(
-                    self.AUTHENTICATOR_CLASS.__name__
-                )
+                f"Must use a authenticator of type {self.AUTHENTICATOR_CLASS.__name__}."
             )
 
     def is_valid(self):

--- a/asyncprawcore/exceptions.py
+++ b/asyncprawcore/exceptions.py
@@ -26,7 +26,7 @@ class RequestException(asyncprawcoreException):
         self.request_args = request_args
         self.request_kwargs = request_kwargs
         super(RequestException, self).__init__(
-            "error with request {}".format(original_exception)
+            f"error with request {original_exception}"
         )
 
 
@@ -41,7 +41,7 @@ class ResponseException(asyncprawcoreException):
         """
         self.response = response
         super(ResponseException, self).__init__(
-            "received {} HTTP response".format(response.status)
+            f"received {response.status} HTTP response"
         )
 
 
@@ -59,9 +59,9 @@ class OAuthException(asyncprawcoreException):
         self.error = error
         self.description = description
         self.response = response
-        message = "{} error processing request".format(error)
+        message = f"{error} error processing request"
         if description:
-            message += " ({})".format(description)
+            message += f" ({description})"
         asyncprawcoreException.__init__(self, message)
 
 
@@ -111,9 +111,7 @@ class Redirect(ResponseException):
         path = urlparse(response.headers["location"]).path
         self.path = path[:-5] if path.endswith(".json") else path
         self.response = response
-        asyncprawcoreException.__init__(
-            self, "Redirect to {}".format(self.path)
-        )
+        asyncprawcoreException.__init__(self, f"Redirect to {self.path}")
 
 
 class ServerError(ResponseException):
@@ -137,7 +135,7 @@ class SpecialError(ResponseException):
         self.reason = resp_dict.get("reason", "")
         self.special_errors = resp_dict.get("special_errors", [])
         asyncprawcoreException.__init__(
-            self, "Special error {!r}".format(self.message)
+            self, f"Special error {self.message!r}"
         )
 
 

--- a/asyncprawcore/rate_limit.py
+++ b/asyncprawcore/rate_limit.py
@@ -47,9 +47,7 @@ class RateLimiter(object):
         sleep_seconds = self.next_request_timestamp - time.time()
         if sleep_seconds <= 0:
             return
-        message = "Sleeping: {:0.2f} seconds prior to call".format(
-            sleep_seconds
-        )
+        message = f"Sleeping: {sleep_seconds:0.2f} seconds prior to call"
         log.debug(message)
         await asyncio.sleep(sleep_seconds)
 

--- a/asyncprawcore/requestor.py
+++ b/asyncprawcore/requestor.py
@@ -40,7 +40,7 @@ class Requestor(object):
         self.set_http(session)
         self._http._default_headers[
             "User-Agent"
-        ] = "{} asyncprawcore/{}".format(user_agent, __version__)
+        ] = f"{user_agent} asyncprawcore/{__version__}"
         self.oauth_url = oauth_url
         self.reddit_url = reddit_url
 

--- a/asyncprawcore/sessions.py
+++ b/asyncprawcore/sessions.py
@@ -1,16 +1,16 @@
 """asyncprawcore.sessions: Provides asyncprawcore.Session and asyncprawcore.session."""
-from copy import deepcopy
+import asyncio
 import logging
 import random
-import asyncio
+from copy import deepcopy
 from json.decoder import JSONDecodeError
-from aiohttp.web import HTTPRequestTimeout
 from urllib.parse import urljoin
-from .codes import codes
+
+from aiohttp.web import HTTPRequestTimeout
 
 from .auth import BaseAuthorizer
+from .codes import codes
 from .const import TIMEOUT
-from .rate_limit import RateLimiter
 from .exceptions import (
     BadJSON,
     BadRequest,
@@ -24,7 +24,9 @@ from .exceptions import (
     TooLarge,
     UnavailableForLegalReasons,
 )
+from .rate_limit import RateLimiter
 from .util import authorization_error_class
+
 
 log = logging.getLogger(__package__)
 
@@ -42,9 +44,7 @@ class RetryStrategy(object):
         """Sleep until we are ready to attempt the request."""
         sleep_seconds = self._sleep_seconds()
         if sleep_seconds is not None:
-            message = "Sleeping: {:0.2f} seconds prior to retry".format(
-                sleep_seconds
-            )
+            message = f"Sleeping: {sleep_seconds:0.2f} seconds prior to retry"
             log.debug(message)
             asyncio.sleep(sleep_seconds)
 
@@ -110,18 +110,16 @@ class Session(object):
 
     @staticmethod
     def _log_request(data, method, params, url):
-        log.debug("Fetching: {} {}".format(method, url))
-        log.debug("Data: {}".format(data))
-        log.debug("Params: {}".format(params))
+        log.debug(f"Fetching: {method} {url}")
+        log.debug(f"Data: {data}")
+        log.debug(f"Params: {params}")
 
     @staticmethod
     def _retry_sleep(retries):
         if retries < 3:
             base = 0 if retries == 2 else 2
             sleep_seconds = base + 2 * random.random()
-            message = "Sleeping: {:0.2f} seconds prior to retry".format(
-                sleep_seconds
-            )
+            message = f"Sleeping: {sleep_seconds:0.2f} seconds prior to retry"
             log.debug(message)
             asyncio.sleep(sleep_seconds)
 
@@ -132,9 +130,7 @@ class Session(object):
 
         """
         if not isinstance(authorizer, BaseAuthorizer):
-            raise InvalidInvocation(
-                "invalid Authorizer: {}".format(authorizer)
-            )
+            raise InvalidInvocation(f"invalid Authorizer: {authorizer}")
         self._authorizer = authorizer
         self._rate_limiter = RateLimiter()
         self._retry_strategy_class = FiniteRetryStrategy
@@ -163,9 +159,7 @@ class Session(object):
             status = repr(saved_exception)
         else:
             status = response.status
-        log.warning(
-            "Retrying due to {} status: {} {}".format(status, method, url)
-        )
+        log.warning(f"Retrying due to {status} status: {method} {url}")
         return await self._request_with_retries(
             data=data,
             json=json,
@@ -192,9 +186,7 @@ class Session(object):
                 timeout=timeout,
             )
             log.debug(
-                "Response: {} ({} bytes)".format(
-                    response.status, response.headers.get("content-length")
-                )
+                f"Response: {response.status} ({response.headers.get('content-length')} bytes)"
             )
             return response, None
         except RequestException as exception:
@@ -249,7 +241,7 @@ class Session(object):
             return
         assert (
             response.status in self.SUCCESS_STATUSES
-        ), "Unexpected status code: {}".format(response.status)
+        ), f"Unexpected status code: {response.status}"
         if response.headers.get("content-length") == "0":
             return ""
         try:
@@ -262,9 +254,7 @@ class Session(object):
             self._authorizer, "refresh"
         ):
             await self._authorizer.refresh()
-        return {
-            "Authorization": "bearer {}".format(self._authorizer.access_token)
-        }
+        return {"Authorization": f"bearer {self._authorizer.access_token}"}
 
     @property
     def _requestor(self):

--- a/examples/caching_requestor.py
+++ b/examples/caching_requestor.py
@@ -40,7 +40,7 @@ class CachingSession(aiohttp.ClientSession):
 async def main():
     """Provide the program's entry point when directly executed."""
     if len(sys.argv) != 2:
-        print("Usage: {} USERNAME".format(sys.argv[0]))
+        print(f"Usage: {sys.argv[0]} USERNAME")
         return 1
 
     caching_requestor = asyncprawcore.Requestor(
@@ -59,12 +59,12 @@ async def main():
 
         async with asyncprawcore.session(authorizer) as session:
             data1 = await session.request(
-                "GET", "/api/v1/user/{}/trophies".format(user)
+                "GET", f"/api/v1/user/{user}/trophies"
             )
 
         async with asyncprawcore.session(authorizer) as session:
             data2 = await session.request(
-                "GET", "/api/v1/user/{}/trophies".format(user)
+                "GET", f"/api/v1/user/{user}/trophies"
             )
 
         for trophy in data1["data"]["trophies"]:
@@ -72,7 +72,7 @@ async def main():
             print(
                 "Original:",
                 trophy["data"]["name"]
-                + (" ({})".format(description) if description else ""),
+                + (f" ({description})" if description else ""),
             )
 
         for trophy in data2["data"]["trophies"]:
@@ -80,7 +80,7 @@ async def main():
             print(
                 "Cached:",
                 trophy["data"]["name"]
-                + (" ({})".format(description) if description else ""),
+                + (f" ({description})" if description else ""),
             )
         print(
             "----\nCached == Original:",

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -20,7 +20,7 @@ class TrustedAuthenticatorTest(asynctest.TestCase):
         url = authenticator.authorize_url(
             "permanent", ["identity", "read"], "a_state"
         )
-        self.assertIn("client_id={}".format(CLIENT_ID), str(url))
+        self.assertIn(f"client_id={CLIENT_ID}", str(url))
         self.assertIn("duration=permanent", str(url))
         self.assertIn("response_type=code", str(url))
         self.assertIn("scope=identity+read", str(url))
@@ -91,7 +91,7 @@ class UntrustedAuthenticatorTest(asynctest.TestCase):
         url = authenticator.authorize_url(
             "permanent", ["identity", "read"], "a_state"
         )
-        self.assertIn("client_id={}".format(CLIENT_ID), str(url))
+        self.assertIn(f"client_id={CLIENT_ID}", str(url))
         self.assertIn("duration=permanent", str(url))
         self.assertIn("response_type=code", str(url))
         self.assertIn("scope=identity+read", str(url))
@@ -104,7 +104,7 @@ class UntrustedAuthenticatorTest(asynctest.TestCase):
         url = authenticator.authorize_url(
             "temporary", ["identity", "read"], "a_state", implicit=True
         )
-        self.assertIn("client_id={}".format(CLIENT_ID), str(url))
+        self.assertIn(f"client_id={CLIENT_ID}", str(url))
         self.assertIn("duration=temporary", str(url))
         self.assertIn("response_type=token", str(url))
         self.assertIn("scope=identity+read", str(url))

--- a/tests/test_requestor.py
+++ b/tests/test_requestor.py
@@ -18,9 +18,7 @@ class RequestorTest(asynctest.TestCase):
             "asyncprawcore:test (by /u/bboe)"
         )
         self.assertEqual(
-            "asyncprawcore:test (by /u/bboe) asyncprawcore/{}".format(
-                asyncprawcore.__version__
-            ),
+            f"asyncprawcore:test (by /u/bboe) asyncprawcore/{asyncprawcore.__version__}",
             self.requestor._http._default_headers["User-Agent"],
         )
 
@@ -67,9 +65,7 @@ class RequestorTest(asynctest.TestCase):
         )
 
         self.assertEqual(
-            "asyncprawcore:test (by /u/bboe) asyncprawcore/{}".format(
-                asyncprawcore.__version__
-            ),
+            f"asyncprawcore:test (by /u/bboe) asyncprawcore/{asyncprawcore.__version__}",
             self.requestor._http._default_headers["User-Agent"],
         )
         self.assertEqual(

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -353,7 +353,7 @@ class SessionTest(asynctest.TestCase):
         with VCR.use_cassette("Session_request__okay_with_0_byte_content"):
             self.session = asyncprawcore.Session(await script_authorizer())
             data = {"model": dumps({"name": "t2"})}
-            path = "/api/multi/user/{}/m/t2".format(USERNAME)
+            path = f"/api/multi/user/{USERNAME}/m/t2"
             response = await self.session.request("DELETE", path, data=data)
             self.assertEqual("", response)
 


### PR DESCRIPTION
Since Python 3.5 is not no longer supported, we should convert to using f-strings since they are simpler to use and read.