### PR TITLE
Implement delayed session creation

### DIFF
--- a/asyncprawcore/requestor.py
+++ b/asyncprawcore/requestor.py
@@ -2,14 +2,15 @@
 
 from __future__ import annotations
 
-import asyncio
-from typing import TYPE_CHECKING, Any
+from contextlib import asynccontextmanager
+from typing import TYPE_CHECKING, Any, AsyncContextManager, Callable
+from warnings import warn
 
 import aiohttp
 from aiohttp import ClientSession
 
 from .const import TIMEOUT
-from .exceptions import InvalidInvocation, RequestException
+from .exceptions import InvalidInvocation, RequestException, ResponseException
 
 if TYPE_CHECKING:
     from asyncio import AbstractEventLoop
@@ -23,7 +24,7 @@ class Requestor:
     def __getattr__(self, attribute: str) -> Any:  # pragma: no cover
         """Pass all undefined attributes to the ``_http`` attribute."""
         if attribute.startswith("__"):
-            raise AttributeError
+            raise AttributeError(attribute)
         return getattr(self._http, attribute)
 
     def __init__(
@@ -32,7 +33,7 @@ class Requestor:
         oauth_url: str = "https://oauth.reddit.com",
         reddit_url: str = "https://www.reddit.com",
         session: ClientSession | None = None,
-        loop: AbstractEventLoop = None,
+        loop: AbstractEventLoop | None = None,
         timeout: float = TIMEOUT,
     ):
         """Create an instance of the Requestor class.
@@ -45,6 +46,12 @@ class Requestor:
             ``"https://www.reddit.com"``).
         :param session: A session instance to handle requests, compatible with
             ``aiohttp.ClientSession()`` (default: ``None``).
+        :param loop: The event loop to run the requestor on (default: ``None``).
+
+            .. Deprecated:: 2.5.0
+
+                The ``loop`` argument is deprecated and will be ignored.
+
         :param timeout: How many seconds to wait for the server to send data before
             giving up (default: ``asyncprawcore.const.TIMEOUT``).
 
@@ -52,33 +59,64 @@ class Requestor:
         # Imported locally to avoid an import cycle, with __init__
         from . import __version__
 
+        if loop is not None:
+            msg = "The loop argument is deprecated and will be ignored."
+            warn(msg, DeprecationWarning, stacklevel=2)
+
         if user_agent is None or len(user_agent) < 7:
             msg = "user_agent is not descriptive"
             raise InvalidInvocation(msg)
 
-        self.loop = loop or asyncio.get_event_loop()
-        self._http = session or aiohttp.ClientSession(
-            loop=self.loop, timeout=aiohttp.ClientTimeout(total=None)
-        )
-        self._http._default_headers["User-Agent"] = (
-            f"{user_agent} asyncprawcore/{__version__}"
-        )
-
+        self.headers = {"User-Agent": f"{user_agent} asyncprawcore/{__version__}"}
         self.oauth_url = oauth_url
         self.reddit_url = reddit_url
         self.timeout = timeout
 
+        self._http = session
+        if self._http is not None and "User-Agent" not in self._http.headers:
+            # ensure user-agent is set
+            self._http.headers.update(self.headers)
+
+    async def _ensure_session(self):
+        """Ensure that the session is open."""
+        if self._http is None or self._http.closed:
+            self._http = aiohttp.ClientSession(
+                headers=self.headers,
+                timeout=aiohttp.ClientTimeout(total=None),
+            )
+
     async def close(self):
         """Call close on the underlying session."""
-        await self._http.close()
+        if self._http is not None and not self._http.closed:
+            await self._http.close()
 
+    @asynccontextmanager
     async def request(
         self, *args: Any, timeout: float | None = None, **kwargs: Any
-    ) -> ClientResponse:
-        """Issue the HTTP request capturing any errors that may occur."""
+    ) -> Callable[..., AsyncContextManager[ClientResponse]]:
+        """Issue the HTTP request capturing any errors that may occur.
+
+        :param args: Positional arguments to pass to ``aiohttp.ClientSession.request``.
+        :param timeout: How many seconds to wait for the server to send data before
+            giving up (default: ``None``).
+        :param kwargs: Keyword arguments to pass to ``aiohttp.ClientSession.request``.
+
+        :returns: The response from the request.
+
+        :raises: RequestException: If an error occurs while issuing the request.
+
+        """
         try:
-            return await self._http.request(
-                *args, timeout=timeout or self.timeout, **kwargs
-            )
+            await self._ensure_session()
+            kwargs_copy = kwargs.copy()
+            async with self._http.request(
+                *args,
+                headers={**self.headers, **kwargs_copy.pop("headers", {})},
+                timeout=timeout or self.timeout,
+                **kwargs_copy,
+            ) as request:
+                yield request
+        except ResponseException as exc:
+            raise exc
         except Exception as exc:  # noqa: BLE001
             raise RequestException(exc, args, kwargs) from None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,6 @@ lint = [
   "ruff ==0.1.*"
 ]
 test = [
-  "mock ==4.*",
   "pytest ==7.*",
   "pytest-asyncio ==0.18.*",
   "pytest-vcr ==1.*",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,6 @@ import asyncio
 import os
 from base64 import b64encode
 
-import aiohttp
 import pytest
 
 from asyncprawcore import Requestor, TrustedAuthenticator, UntrustedAuthenticator
@@ -33,17 +32,11 @@ def image_path():
 
 
 @pytest.fixture
-async def requestor(event_loop: asyncio.AbstractEventLoop):
+async def requestor():
     """Return path to image."""
-    session = aiohttp.ClientSession(
-        loop=event_loop,
-        headers={"Accept-Encoding": "identity"},
-        timeout=aiohttp.ClientTimeout(total=None),
-    )
-    yield Requestor(
-        "asyncprawcore:test (by u/Lil_SpazJoekp)", session=session, loop=event_loop
-    )
-    await session.close()
+    _requestor = Requestor("asyncprawcore:test (by u/Lil_SpazJoekp)")
+    yield _requestor
+    await _requestor.close()
 
 
 @pytest.fixture

--- a/tests/integration/test_sessions.py
+++ b/tests/integration/test_sessions.py
@@ -266,7 +266,7 @@ class TestSession(IntegrationTest):
         assert (await exception_info.value.message()).startswith("\n<!doctype html>")
 
     async def test_request__too__many_requests__without_retry_headers(self, requestor):
-        requestor._http.headers.update({"User-Agent": "python-requests/2.25.1"})
+        requestor.headers.update({"User-Agent": "python-requests/2.25.1"})
         authorizer = asyncprawcore.ReadOnlyAuthorizer(
             asyncprawcore.TrustedAuthenticator(
                 requestor,


### PR DESCRIPTION
Reference discussion: https://github.com/praw-dev/asyncpraw/issues/167

The changes have been implemented as requested. There's a really important note I've noticed and would like to add here though - due to how the requests are handled (without using the context manager like documentation says), the code calling the `request` method needs to handle releasing the response object. Normally, this would be handled by the context manager's `__aexit__` method of the `ClientResponse` that's returned. Reference code: https://github.com/aio-libs/aiohttp/blob/ca51ebd5ffb77f66218933e017a0c924f5810b4d/aiohttp/client_reqrep.py#L1134

Since I haven't seen anything doing so in `asyncpraw` itself, it means that the entire library is "leaking" unclosed client response objects, much like you'd open a file and forget to close it. I'm not sure how `aiohttp` handles cases like this, but it should not be a thing. To fix this, either `asyncpraw` (or any other library using `asyncprawcore`) has to include a `finally` clause followed by `response.release()`, or the `request` method here needs to be converted to use the async context manager (probably by becoming one in itself), just like the documentation explains so. Something like:

```py
from contextlib import asynccontextmanager

class Requestor:
    # bad
    def request(self, *args, **kwargs):
        return await self._session.request(*args, **kwargs)

    # good
    @asynccontextmanager
    def request(self, *args, **kwargs):
        async with self._session.request(*args, **kwargs) as response:
            yield response
```

Usage of this would then change in `asyncpraw` like so:

```py
class Reddit:
    # current
    async def request(self, ...):
        response = await self._core.request(...)
        # response.json or response.text are read
        # response object isn't released afterwards

    # changed
    async def request(self, ...):
        async with self._core.request(...) as response:
            # use response to read json or text from it
            # using the context manager will release the response properly
```

Should this also become a part of this PR?